### PR TITLE
Baro gyre gendata

### DIFF
--- a/verification/tutorial_barotropic_gyre/input/gendata.py
+++ b/verification/tutorial_barotropic_gyre/input/gendata.py
@@ -1,41 +1,41 @@
 #!/usr/bin/env python
 def gendata():
-  """
+    """
     Generate MITgcm tutorial_barotropic_gyre input files
 
     Outputs:
-     topog.box:    Domain depths ( m       )
-     windx.sin_y:  Wind stress   ( Nm^{-2} )
-  """
+       topog.box:    Domain depths ( m       )
+       windx.sin_y:  Wind stress   ( Nm^{-2} )
+    """
 
-  import numpy as np
+    import numpy as np
 
-  # Set ouput I/O to double precision IEEE big endian,
-  # the MITgcm default.
-  ofmt = '>f8'
+    # Set ouput I/O to double precision IEEE big endian,
+    # the MITgcm default.
+    ofmt = '>f8'
 
-  # Domain depth and size in X and Y grid points.
-  Ho = 5000
-  nx = 60
-  ny = 60
+    # Domain depth and size in X and Y grid points.
+    Ho = 5000
+    nx = 60
+    ny = 60
 
-  # Generate bathymetry with flat bottom at z=-Ho
-  h = -Ho*np.ones([nx, ny])
-  # Walls
-  h[-1, :] = 0
-  h[:, -1] = 0
-  with open('topog.box','wb') as fid:
-    h.astype(ofmt).tofile(fid,"") 
+    # Generate bathymetry with flat bottom at z=-Ho
+    h = -Ho*np.ones([nx, ny])
+    # Walls
+    h[-1, :] = 0
+    h[:, -1] = 0
+    with open('topog.box','wb') as fid:
+        h.astype(ofmt).tofile(fid,"")
 
-  # Generate zonal wind-stress file that is sin with period of dmain north-south extent
-  # and maximum of 0.1 Nm^{2}
-  tauMax = 0.1
-  x = (np.arange(1,nx+1)-0.5) / (nx-1.) # nx-1 accounts for a solid wall
-  y = (np.arange(1,ny+1)-0.5) / (ny-1.) # ny-1 accounts for a solid wall
-  X, Y = np.meshgrid(x,y)
-  tau = tauMax*np.sin(np.pi*Y)
-  with open('windx.sin_y','wb') as fid:
-    tau.astype(ofmt).tofile(fid,"") 
+    # Generate zonal wind-stress file that is sin with period of dmain north-south extent
+    # and maximum of 0.1 Nm^{2}
+    tauMax = 0.1
+    x = (np.arange(1,nx+1)-0.5) / (nx-1.) # nx-1 accounts for a solid wall
+    y = (np.arange(1,ny+1)-0.5) / (ny-1.) # ny-1 accounts for a solid wall
+    X, Y = np.meshgrid(x,y)
+    tau = tauMax*np.sin(np.pi*Y)
+    with open('windx.sin_y','wb') as fid:
+        tau.astype(ofmt).tofile(fid,"")
 
 if __name__ == '__main__':
- gendata()
+    gendata()

--- a/verification/tutorial_barotropic_gyre/input/gendata.py
+++ b/verification/tutorial_barotropic_gyre/input/gendata.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+
+import numpy as np
+
 def gendata():
     """
     Generate MITgcm tutorial_barotropic_gyre input files
@@ -7,8 +10,6 @@ def gendata():
        topog.box:    Domain depths ( m       )
        windx.sin_y:  Wind stress   ( Nm^{-2} )
     """
-
-    import numpy as np
 
     # Set ouput I/O to double precision IEEE big endian,
     # the MITgcm default.

--- a/verification/tutorial_barotropic_gyre/input/gendata.py
+++ b/verification/tutorial_barotropic_gyre/input/gendata.py
@@ -24,9 +24,8 @@ def gendata():
   # Walls
   h[-1, :] = 0
   h[:, -1] = 0
-  fid=open('topog.box','wb') 
-  h.astype(ofmt).tofile(fid,"") 
-  fid.close()
+  with open('topog.box','wb') as fid:
+    h.astype(ofmt).tofile(fid,"") 
 
   # Generate zonal wind-stress file that is sin with period of dmain north-south extent
   # and maximum of 0.1 Nm^{2}
@@ -35,9 +34,8 @@ def gendata():
   y = (np.arange(1,ny+1)-0.5) / (ny-1.) # ny-1 accounts for a solid wall
   X, Y = np.meshgrid(x,y)
   tau = tauMax*np.sin(np.pi*Y)
-  fid=open('windx.sin_y','wb') 
-  tau.astype(ofmt).tofile(fid,"") 
-  fid.close()
+  with open('windx.sin_y','wb') as fid:
+    tau.astype(ofmt).tofile(fid,"") 
 
 if __name__ == '__main__':
  gendata()

--- a/verification/tutorial_barotropic_gyre/input/gendata.py
+++ b/verification/tutorial_barotropic_gyre/input/gendata.py
@@ -21,7 +21,7 @@ def gendata():
     ny = 60
 
     # Generate bathymetry with flat bottom at z=-Ho
-    h = -Ho*np.ones([nx, ny])
+    h = -Ho*np.ones((nx, ny))
     # Walls
     h[-1, :] = 0
     h[:, -1] = 0


### PR DESCRIPTION
Various minor style tweaks.

 - use context managers to open the output files. This ensures that the file handles are always closed once we're finished with them
 - use four space indentation to be consistent with accepted python styles
 - import the `numpy` module before the function definition, again to be consistent with accepted python style
 - pass the `np.ones` command a tuple for the array size, rather than a list. 